### PR TITLE
Add release checksum artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,19 @@ jobs:
           set -euo pipefail
           cp service.json release-assets/service.json
 
+      - name: Generate release checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          (
+            cd release-assets
+            sha256sum \
+              echo-service-win32.zip \
+              echo-service-linux.tar.gz \
+              echo-service-darwin.tar.gz \
+              service.json > SHA256SUMS.txt
+          )
+
       - name: Compute release version
         id: version
         shell: bash
@@ -122,4 +135,5 @@ jobs:
             release-assets/echo-service-linux.tar.gz
             release-assets/echo-service-darwin.tar.gz
             release-assets/service.json
+            release-assets/SHA256SUMS.txt
           generate_release_notes: true

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -8,3 +8,10 @@ Current first-pass direction:
 - package the minimal sample service into a release artifact under `dist/`
 - include `service.json`, runtime payload, and config
 - use the produced artifact as the thing later consumed by the shared harness
+
+Release assets:
+- `echo-service-win32.zip`
+- `echo-service-linux.tar.gz`
+- `echo-service-darwin.tar.gz`
+- `service.json`
+- `SHA256SUMS.txt`


### PR DESCRIPTION
## Intent
Closes #6 by making Echo Service releases include the same checksum artifact contract as the other current service repos.

## Change
- Generate `SHA256SUMS.txt` in the release aggregation job.
- Upload `SHA256SUMS.txt` alongside platform archives and `service.json`.
- Document the expected release asset set.

## Verification
- `./scripts/test.ps1`
- `./scripts/package.ps1`
- `./scripts/verify.ps1`
- `git diff --check`

## Risk
Low. Runtime behavior is unchanged; this only affects release asset creation.