### PR TITLE
Migrate manifest to healthchecks array

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The browser UI and API can switch the dedicated HTTP/TCP health targets between:
 - `error`
 - `stopped`
 
-That makes the harness useful for future Service Lasso work on real HTTP/TCP health probing without changing the service’s primary manifest healthcheck yet.
+That makes the harness useful for future Service Lasso work on real HTTP/TCP health probing while the service manifest keeps `healthchecks[]` on the process readiness default.
 
 ## Verification
 

--- a/docs/openspec-drafts/SPEC-SERVICE-TEMPLATE-REPO.md
+++ b/docs/openspec-drafts/SPEC-SERVICE-TEMPLATE-REPO.md
@@ -197,7 +197,7 @@ Current health-model direction:
 - default health model is **process**
 - other health models are allowed when explicitly declared by the service config
 
-Ref/code-backed donor healthcheck types observed:
+Ref/code-backed donor healthchecks[] types observed:
 - `http`
 - `tcp`
 - `file`

--- a/docs/reference/EXAMPLE-service.json
+++ b/docs/reference/EXAMPLE-service.json
@@ -31,8 +31,11 @@
       "ECHO_MESSAGE": "hello from service-template"
     },
     "depend_on": [],
-    "healthcheck": {
-      "type": "process"
-    }
+    "healthchecks": [
+      {
+        "id": "process-ready",
+        "type": "process"
+      }
+    ]
   }
 }

--- a/docs/reference/SERVICE-STRUCTURE-REVIEW.md
+++ b/docs/reference/SERVICE-STRUCTURE-REVIEW.md
@@ -231,7 +231,7 @@ Most services follow this high-level shape:
 - `env`
 - `globalenv`
 - `depend_on`
-- `healthcheck`
+- `healthchecks`
 - `authentication`
 - `outputvarregex`
 - `urls`
@@ -262,7 +262,7 @@ Services explicitly declare dependency order.
 
 This is core and should survive.
 
-### Pattern 4 - `healthcheck`
+### Pattern 4 - `healthchecks[]`
 Services declare their runtime health expectations.
 
 This is core and should survive, but may need normalization.
@@ -491,7 +491,7 @@ The template repo should likely include:
 
 ### Optional
 - sample config
-- healthcheck probe script
+- healthchecks[] probe script
 - migration/setup scripts
 - platform-specific packaging helpers
 

--- a/docs/reference/shared-runtime/SERVICE-MANAGER-BEHAVIOR.md
+++ b/docs/reference/shared-runtime/SERVICE-MANAGER-BEHAVIOR.md
@@ -163,7 +163,7 @@ This determines reserved ports, exposed URLs, and how service endpoints are desc
 
 ### F. Health/readiness
 Fields used include:
-- `healthcheck`
+- `healthchecks`
 
 This determines how the runtime checks whether a service is started/healthy.
 

--- a/docs/service-contract.md
+++ b/docs/service-contract.md
@@ -10,7 +10,7 @@ Key files:
 - `scripts/package.*` - packaging entrypoints
 - `runtime/` - generated runtime files during local runs
 - `config/` - example config inputs
-- `docs/service-json-reference.md` - one-stop reference for `service.json` fields, healthcheck setup, and first-pass contract guidance
+- `docs/service-json-reference.md` - one-stop reference for `service.json` fields, `healthchecks[]` setup, and first-pass contract guidance
 
 This service is intentionally harness-oriented.
 It exists to support runtime integration, supervision, persistence, and demo verification rather than end-user product behavior.

--- a/docs/service-json-reference.md
+++ b/docs/service-json-reference.md
@@ -13,7 +13,7 @@ It is meant to make the template usable without forcing service authors to recon
 - `actions`
 - `execconfig`
 - env / dependencies / ports
-- healthcheck direction
+- `healthchecks[]` direction
 - examples
 - what is currently canonical vs still illustrative
 
@@ -23,7 +23,7 @@ The current template direction is:
 - **default health model = `process`**
 - other health models are used only when explicitly declared by service config
 
-Ref/code-backed donor healthcheck types observed:
+Ref/code-backed donor healthchecks[] types observed:
 - `http`
 - `tcp`
 - `file`
@@ -80,9 +80,12 @@ The current sample in this repo is:
       "ECHO_MESSAGE": "hello from service-template"
     },
     "depend_on": [],
-    "healthcheck": {
-      "type": "process"
-    }
+    "healthchecks": [
+      {
+        "id": "process-ready",
+        "type": "process"
+      }
+    ]
   }
 }
 ```
@@ -238,7 +241,7 @@ Current direction:
 - use this for services that require another service/runtime/provider first
 - keep empty for the minimal sample
 
-## Healthcheck
+## Healthchecks
 
 ### Default rule
 Current rule:
@@ -246,15 +249,18 @@ Current rule:
 
 Example:
 ```json
-"healthcheck": {
-  "type": "process"
-}
+"healthchecks": [
+  {
+    "id": "process-ready",
+    "type": "process"
+  }
+]
 ```
 
 This is the right default for a simple sample service.
 
-### Observed donor healthcheck types
-The donor runtime/code shows these healthcheck types:
+### Observed donor healthchecks[] types
+The donor runtime/code shows these healthchecks[] types:
 - `http`
 - `tcp`
 - `file`
@@ -262,66 +268,81 @@ The donor runtime/code shows these healthcheck types:
 
 `process` is the current template default direction, even though the donor code paths most explicitly surfaced in ref material are the four types above.
 
-### `process` healthcheck
+### `process` healthchecks[] item
 Use when:
 - service health is adequately represented by the process being up/running
 - you do not need a deeper readiness endpoint yet
 
 Sample:
 ```json
-"healthcheck": {
-  "type": "process"
-}
+"healthchecks": [
+  {
+    "id": "process-ready",
+    "type": "process"
+  }
+]
 ```
 
-### `http` healthcheck
+### `http` healthchecks[] item
 Use when:
 - the service exposes an HTTP readiness or health endpoint
 
 Sample:
 ```json
-"healthcheck": {
-  "type": "http",
-  "url": "http://localhost:${SERVICE_PORT}/health",
-  "expected_status": 200
-}
+"healthchecks": [
+  {
+    "id": "http-ready",
+    "type": "http",
+    "url": "http://localhost:${SERVICE_PORT}/health",
+    "expected_status": 200
+  }
+]
 ```
 
-### `tcp` healthcheck
+### `tcp` healthchecks[] item
 Use when:
 - readiness is best represented by a socket accepting connections
 
 Sample:
 ```json
-"healthcheck": {
-  "type": "tcp"
-}
+"healthchecks": [
+  {
+    "id": "tcp-ready",
+    "type": "tcp"
+  }
+]
 ```
 
 Current donor behavior suggests this relies on the configured service host/port.
 
-### `file` healthcheck
+### `file` healthchecks[] item
 Use when:
 - the service creates a file that represents successful readiness/setup
 
 Sample:
 ```json
-"healthcheck": {
-  "type": "file",
-  "file": "${SERVICE_HOME}/.state/runtime/ready.txt"
-}
+"healthchecks": [
+  {
+    "id": "ready-file",
+    "type": "file",
+    "file": "${SERVICE_HOME}/.state/runtime/ready.txt"
+  }
+]
 ```
 
-### `variable` healthcheck
+### `variable` healthchecks[] item
 Use when:
 - a specific resolved/exported variable is the readiness signal
 
 Sample:
 ```json
-"healthcheck": {
-  "type": "variable",
-  "variable": "${SERVICE_URL}"
-}
+"healthchecks": [
+  {
+    "id": "service-url-ready",
+    "type": "variable",
+    "variable": "${SERVICE_URL}"
+  }
+]
 ```
 
 ## Other important manifest aspects

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -11,7 +11,7 @@ Current validation direction:
 - local and CI usage should share the same harness contract path
 - the manifest still uses `process` as the primary health model, while the harness now also exposes dedicated HTTP and TCP health targets for future runtime tests
 
-Ref/code-backed donor healthcheck types observed:
+Ref/code-backed donor healthchecks[] types observed:
 - `http`
 - `tcp`
 - `file`

--- a/main_test.go
+++ b/main_test.go
@@ -569,7 +569,10 @@ func TestForkChildAndStartChildTrackProcesses(t *testing.T) {
 }
 
 func TestRunServesHTTPAndClosesGracefully(t *testing.T) {
-	app := newTestHarnessApp(t)
+	app := newTestHarnessAppWithEnv(t, map[string]string{
+		"ECHO_HTTP_HEALTH_PORT": findFreePort(t),
+		"ECHO_TCP_PORT":         findFreePort(t),
+	})
 	app.port = findFreePort(t)
 
 	serverErrCh := make(chan error, 1)
@@ -616,10 +619,12 @@ func TestSubprocessCloseAndAbortFlows(t *testing.T) {
 		logPath, statePath, dbPath := makeTestPaths(t)
 		port := findFreePort(t)
 		command := startHarnessProcess(t, binary, map[string]string{
-			"ECHO_PORT":       port,
-			"ECHO_LOG_PATH":   logPath,
-			"ECHO_STATE_PATH": statePath,
-			"ECHO_DB_PATH":    dbPath,
+			"ECHO_PORT":             port,
+			"ECHO_LOG_PATH":         logPath,
+			"ECHO_STATE_PATH":       statePath,
+			"ECHO_DB_PATH":          dbPath,
+			"ECHO_HTTP_HEALTH_PORT": findFreePort(t),
+			"ECHO_TCP_PORT":         findFreePort(t),
 		})
 
 		baseURL := "http://127.0.0.1:" + port
@@ -648,10 +653,12 @@ func TestSubprocessCloseAndAbortFlows(t *testing.T) {
 		logPath, statePath, dbPath := makeTestPaths(t)
 		port := findFreePort(t)
 		command := startHarnessProcess(t, binary, map[string]string{
-			"ECHO_PORT":       port,
-			"ECHO_LOG_PATH":   logPath,
-			"ECHO_STATE_PATH": statePath,
-			"ECHO_DB_PATH":    dbPath,
+			"ECHO_PORT":             port,
+			"ECHO_LOG_PATH":         logPath,
+			"ECHO_STATE_PATH":       statePath,
+			"ECHO_DB_PATH":          dbPath,
+			"ECHO_HTTP_HEALTH_PORT": findFreePort(t),
+			"ECHO_TCP_PORT":         findFreePort(t),
 		})
 
 		baseURL := "http://127.0.0.1:" + port
@@ -691,14 +698,15 @@ func TestServiceManifestMatchesHarnessContract(t *testing.T) {
 	}
 
 	var manifest struct {
-		ID          string            `json:"id"`
-		Name        string            `json:"name"`
-		Executable  string            `json:"executable"`
-		Args        []string          `json:"args"`
-		Env         map[string]string `json:"env"`
-		Healthcheck struct {
+		ID           string            `json:"id"`
+		Name         string            `json:"name"`
+		Executable   string            `json:"executable"`
+		Args         []string          `json:"args"`
+		Env          map[string]string `json:"env"`
+		Healthchecks []struct {
+			ID   string `json:"id"`
 			Type string `json:"type"`
-		} `json:"healthcheck"`
+		} `json:"healthchecks"`
 	}
 	if err := json.Unmarshal(rawManifest, &manifest); err != nil {
 		t.Fatalf("decode service.json failed: %v", err)
@@ -713,8 +721,14 @@ func TestServiceManifestMatchesHarnessContract(t *testing.T) {
 	if len(manifest.Args) != 2 || manifest.Args[0] != "run" || manifest.Args[1] != "." {
 		t.Fatalf("unexpected args: %#v", manifest.Args)
 	}
-	if manifest.Healthcheck.Type != "process" {
-		t.Fatalf("unexpected healthcheck type: %s", manifest.Healthcheck.Type)
+	if len(manifest.Healthchecks) != 1 {
+		t.Fatalf("expected one healthchecks[] item, got %d", len(manifest.Healthchecks))
+	}
+	if manifest.Healthchecks[0].ID != "process-ready" {
+		t.Fatalf("unexpected healthchecks[] id: %s", manifest.Healthchecks[0].ID)
+	}
+	if manifest.Healthchecks[0].Type != "process" {
+		t.Fatalf("unexpected healthchecks[] type: %s", manifest.Healthchecks[0].Type)
 	}
 	requiredEnv := []string{"ECHO_PORT", "ECHO_LOG_PATH", "ECHO_STATE_PATH", "ECHO_DB_PATH"}
 	requiredEnv = append(requiredEnv, "ECHO_HTTP_HEALTH_PORT", "ECHO_TCP_PORT")

--- a/service.json
+++ b/service.json
@@ -33,7 +33,10 @@
       "kind": "local"
     }
   ],
-  "healthcheck": {
-    "type": "process"
-  }
+  "healthchecks": [
+    {
+      "id": "process-ready",
+      "type": "process"
+    }
+  ]
 }


### PR DESCRIPTION
Closes #9.

## Summary
- Migrates the service manifest from singular `healthcheck` to canonical `healthchecks[]` with a stable `process-ready` id.
- Updates the manifest contract test to assert the healthchecks array shape.
- Updates checked-in examples and docs so repo guidance no longer teaches the singular key.
- Hardens server/subprocess tests to allocate dedicated health ports dynamically so verification is not blocked by local default-port occupancy.

## Validation
- `rg -n '"healthcheck"|`healthcheck`|\bhealthcheck\b|tcphost|tcpport' .` returned no matches.
- `go test ./...`
- `pwsh -NoLogo -NoProfile -File .\scripts\verify.ps1`
- `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1`
- Canonical demo recycle: `npm run build`, `node scripts/demo-gate.mjs ... --json`, `node scripts/demo-verify-canonical.mjs ... --json`

Evidence: `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260722-002551\`.
