### PR TITLE
Migrate EchoService manifest to canonical endpoints[]

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,17 @@ Its job is to provide:
 - stdout and stderr emission actions for log-capture testing
 - durable log, state, and SQLite writes for persistence testing
 
-## Main endpoints
+## Manifest endpoints
+
+The package manifest declares three concrete listeners and resolves the existing runtime env variables from them:
+
+- `service` - main HTTP listener, default port `4010`
+- `http_health` - dedicated HTTP health listener, default port `4011`
+- `tcp_health` - dedicated TCP health listener, default port `4012`
+
+The `ui`, `service_health`, and `http_health_url` URL endpoints target those listeners. Service Lasso can resolve all of them through `${endpoint.<id>.<field>}` selectors without relying on legacy top-level `urls`, `ports`, or `portmapping` fields.
+
+## Main HTTP routes
 
 - `GET /`
 - `GET /health`

--- a/docs/reference/EXAMPLE-service.json
+++ b/docs/reference/EXAMPLE-service.json
@@ -1,41 +1,101 @@
 {
   "id": "echo-service",
   "name": "Echo Service",
-  "description": "Minimal sample service used to prove the service-template contract.",
+  "description": "Go-based harness service used for Service Lasso integration, runtime hardening, and supervision testing.",
+  "version": "0.3.0",
   "enabled": true,
-  "version": "0.1.0",
-  "logoutput": true,
-  "icon": "terminal",
-  "servicetype": 50,
-  "servicelocation": 10,
-  "actions": {
-    "install": {
-      "description": "Prepare the sample runtime payload if needed."
-    },
-    "config": {
-      "description": "Materialize effective runtime config for the sample service."
-    },
-    "start": {
-      "description": "Start the sample echo service."
-    },
-    "stop": {
-      "description": "Stop the sample echo service gracefully."
-    }
+  "executable": "go",
+  "args": ["run", "."],
+  "env": {
+    "ECHO_MESSAGE": "hello from echo-service harness",
+    "ECHO_PORT": "${endpoint.service.port}",
+    "ECHO_HTTP_HEALTH_PORT": "${endpoint.http_health.port}",
+    "ECHO_TCP_PORT": "${endpoint.tcp_health.port}",
+    "ECHO_LOG_PATH": "./runtime/echo.log",
+    "ECHO_STATE_PATH": "./runtime/state.json",
+    "ECHO_DB_PATH": "./runtime/echo.sqlite",
+    "SERVICE_LASSO_GLOBAL_ENV_JSON": "{\"ECHO_ENV_CHANNEL\":\"demo\"}"
   },
-  "execconfig": {
-    "serviceorder": 100,
-    "serviceport": 0,
-    "execcwd": "runtime",
-    "executable": "echo-service",
-    "env": {
-      "ECHO_MESSAGE": "hello from service-template"
+  "endpoints": [
+    {
+      "id": "service",
+      "kind": "network",
+      "label": "Service HTTP",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "http",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 4010,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true,
+      "primary": true
     },
-    "depend_on": [],
-    "healthchecks": [
-      {
-        "id": "process-ready",
-        "type": "process"
-      }
-    ]
-  }
+    {
+      "id": "http_health",
+      "kind": "network",
+      "label": "Dedicated HTTP health",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "http",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 4011,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "tcp_health",
+      "kind": "network",
+      "label": "Dedicated TCP health",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "tcp",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 4012,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "ui",
+      "kind": "url",
+      "label": "ui",
+      "target": "service",
+      "url": "http://${endpoint.service.bind}:${endpoint.service.port}/",
+      "exposure": "local",
+      "required": true,
+      "primary": true
+    },
+    {
+      "id": "service_health",
+      "kind": "url",
+      "label": "service",
+      "target": "service",
+      "url": "http://${endpoint.service.bind}:${endpoint.service.port}/health",
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "http_health_url",
+      "kind": "url",
+      "label": "http-health",
+      "target": "http_health",
+      "url": "http://${endpoint.http_health.bind}:${endpoint.http_health.port}/health",
+      "exposure": "local",
+      "required": true
+    }
+  ],
+  "healthchecks": [
+    {
+      "id": "process-ready",
+      "type": "process"
+    }
+  ]
 }

--- a/docs/service-contract.md
+++ b/docs/service-contract.md
@@ -17,6 +17,8 @@ It exists to support runtime integration, supervision, persistence, and demo ver
 
 Current harness-specific surfaces include:
 - dedicated HTTP and TCP health targets for realistic health-probe testing
+- canonical `endpoints[]` declarations for the main HTTP, dedicated HTTP health, and dedicated TCP health listeners
+- `${endpoint.<id>.<field>}` selectors that feed resolved listener ports into the existing `ECHO_*` runtime variables
 - env and global-env reporting endpoints
 - a Service Lasso oriented output endpoint at `GET /service-lasso/output`
 - stdout and stderr emission actions for log-capture testing

--- a/docs/service-json-reference.md
+++ b/docs/service-json-reference.md
@@ -1,10 +1,10 @@
 # service.json Reference
 
-_Status: first-pass reference_
+_Status: current package reference_
 
-This doc is the one-stop reference for the current `service.json` direction inside `service-template`.
+This doc is the package-level reference for the Echo Service `service.json` manifest.
 
-It is meant to make the template usable without forcing service authors to reconstruct the contract from scattered notes.
+The core Service Lasso repository owns the full schema. This page records the subset used by Echo Service and follows the canonical `endpoints[]` contract.
 
 ## What this doc covers
 
@@ -12,7 +12,7 @@ It is meant to make the template usable without forcing service authors to recon
 - common top-level fields
 - `actions`
 - `execconfig`
-- env / dependencies / ports
+- env, dependencies, and `endpoints[]`
 - `healthchecks[]` direction
 - examples
 - what is currently canonical vs still illustrative
@@ -42,53 +42,55 @@ At a high level it carries:
 - dependency hints
 - health expectations
 
-## Current sample manifest
+## Canonical endpoint authoring pattern
 
-The current sample in this repo is:
+The checked-in [`service.json`](../service.json) declares each listener as a network endpoint, feeds resolved ports into the existing `ECHO_*` environment variables, and declares operator-facing links as URL endpoints. A reduced example is:
 
 ```json
 {
   "id": "echo-service",
   "name": "Echo Service",
-  "description": "Minimal sample service used to prove the service-template contract.",
+  "description": "Go-based harness service used for Service Lasso integration, runtime hardening, and supervision testing.",
   "enabled": true,
-  "version": "0.1.0",
-  "logoutput": true,
-  "icon": "terminal",
-  "servicetype": 50,
-  "servicelocation": 10,
-  "actions": {
-    "install": {
-      "description": "Prepare the sample runtime payload if needed."
-    },
-    "config": {
-      "description": "Materialize effective runtime config for the sample service."
-    },
-    "start": {
-      "description": "Start the sample echo service."
-    },
-    "stop": {
-      "description": "Stop the sample echo service gracefully."
-    }
+  "version": "0.3.0",
+  "executable": "go",
+  "args": ["run", "."],
+  "env": {
+    "ECHO_PORT": "${endpoint.service.port}",
+    "ECHO_HTTP_HEALTH_PORT": "${endpoint.http_health.port}",
+    "ECHO_TCP_PORT": "${endpoint.tcp_health.port}"
   },
-  "execconfig": {
-    "serviceorder": 100,
-    "serviceport": 0,
-    "execcwd": "runtime",
-    "executable": "echo-service",
-    "env": {
-      "ECHO_MESSAGE": "hello from service-template"
+  "endpoints": [
+    {
+      "id": "service",
+      "kind": "network",
+      "transport": "tcp",
+      "protocol": "http",
+      "bind": "127.0.0.1",
+      "port": { "default": 4010, "strategy": "preferred" },
+      "exposure": "local",
+      "required": true,
+      "primary": true
     },
-    "depend_on": [],
-    "healthchecks": [
-      {
-        "id": "process-ready",
-        "type": "process"
-      }
-    ]
-  }
+    {
+      "id": "ui",
+      "kind": "url",
+      "target": "service",
+      "url": "http://${endpoint.service.bind}:${endpoint.service.port}/",
+      "exposure": "local",
+      "primary": true
+    }
+  ],
+  "healthchecks": [
+    {
+      "id": "process-ready",
+      "type": "process"
+    }
+  ]
 }
 ```
+
+The full manifest also declares the dedicated `http_health` and `tcp_health` network endpoints plus the `service_health` and `http_health_url` URL endpoints.
 
 ## Top-level fields
 
@@ -193,11 +195,6 @@ Example:
 ```json
 "serviceorder": 100
 ```
-
-### `serviceport`
-Primary service port.
-
-In the sample, `0` is being used as a simple first-pass placeholder/default meaning “no fixed service port required by this sample”.
 
 ### `execcwd`
 Execution working directory.
@@ -354,15 +351,16 @@ Current broader Service Lasso direction includes:
 
 The sample template keeps this minimal for now.
 
-### Ports and URLs
-Donor material shows additional fields such as:
-- `serviceportsecondary`
-- `serviceportconsole`
-- `serviceportdebug`
-- `portmapping`
-- `urls`
+### Endpoints
 
-These are not all used in the minimal sample, but they remain relevant for more complex services.
+Use top-level `endpoints[]` for every service interface or resource:
+
+- network listeners use `kind: "network"` with a named `id`, bind, protocol, and port policy
+- operator-facing links use `kind: "url"` and target their network endpoint
+- runtime variables resolve endpoint data with `${endpoint.<id>.<field>}` selectors
+- compatibility aliases, when required, stay in `env` or `globalenv`
+
+Do not author new manifests with legacy top-level `ports`, `portmapping`, or `urls`, or with donor-style `serviceport*` fields. Historical donor-analysis documents under `docs/reference/` may still name those fields when describing the source system.
 
 ### Runtime-provider relationships
 Donor material also shows patterns such as:
@@ -381,6 +379,7 @@ The minimal sample does not use this yet.
 - `execconfig` as the execution contract section
 - explicit `env`
 - explicit `depend_on`
+- canonical `endpoints[]` with `${endpoint.<id>.<field>}` selectors
 - default health model of `process`
 - explicit override to other health models when needed
 

--- a/service.json
+++ b/service.json
@@ -8,29 +8,88 @@
   "args": ["run", "."],
   "env": {
     "ECHO_MESSAGE": "hello from echo-service harness",
-    "ECHO_PORT": "4010",
-    "ECHO_HTTP_HEALTH_PORT": "4011",
-    "ECHO_TCP_PORT": "4012",
+    "ECHO_PORT": "${endpoint.service.port}",
+    "ECHO_HTTP_HEALTH_PORT": "${endpoint.http_health.port}",
+    "ECHO_TCP_PORT": "${endpoint.tcp_health.port}",
     "ECHO_LOG_PATH": "./runtime/echo.log",
     "ECHO_STATE_PATH": "./runtime/state.json",
     "ECHO_DB_PATH": "./runtime/echo.sqlite",
     "SERVICE_LASSO_GLOBAL_ENV_JSON": "{\"ECHO_ENV_CHANNEL\":\"demo\"}"
   },
-  "urls": [
+  "endpoints": [
     {
+      "id": "service",
+      "kind": "network",
+      "label": "Service HTTP",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "http",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 4010,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true,
+      "primary": true
+    },
+    {
+      "id": "http_health",
+      "kind": "network",
+      "label": "Dedicated HTTP health",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "http",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 4011,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "tcp_health",
+      "kind": "network",
+      "label": "Dedicated TCP health",
+      "direction": "inbound",
+      "transport": "tcp",
+      "protocol": "tcp",
+      "bind": "127.0.0.1",
+      "port": {
+        "default": 4012,
+        "strategy": "preferred"
+      },
+      "exposure": "local",
+      "required": true
+    },
+    {
+      "id": "ui",
+      "kind": "url",
       "label": "ui",
-      "url": "http://127.0.0.1:4010/",
-      "kind": "local"
+      "target": "service",
+      "url": "http://${endpoint.service.bind}:${endpoint.service.port}/",
+      "exposure": "local",
+      "required": true,
+      "primary": true
     },
     {
+      "id": "service_health",
+      "kind": "url",
       "label": "service",
-      "url": "http://127.0.0.1:4010/health",
-      "kind": "local"
+      "target": "service",
+      "url": "http://${endpoint.service.bind}:${endpoint.service.port}/health",
+      "exposure": "local",
+      "required": true
     },
     {
+      "id": "http_health_url",
+      "kind": "url",
       "label": "http-health",
-      "url": "http://127.0.0.1:4011/health",
-      "kind": "local"
+      "target": "http_health",
+      "url": "http://${endpoint.http_health.bind}:${endpoint.http_health.port}/health",
+      "exposure": "local",
+      "required": true
     }
   ],
   "healthchecks": [

--- a/service_json_test.go
+++ b/service_json_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestServiceManifestUsesCanonicalEndpoints(t *testing.T) {
+	raw, err := os.ReadFile("service.json")
+	if err != nil {
+		t.Fatalf("read service.json: %v", err)
+	}
+
+	var topLevel map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &topLevel); err != nil {
+		t.Fatalf("decode service.json: %v", err)
+	}
+	for _, legacyField := range []string{"ports", "portmapping", "urls"} {
+		if _, exists := topLevel[legacyField]; exists {
+			t.Fatalf("service.json must not author legacy top-level %q", legacyField)
+		}
+	}
+
+	var manifest struct {
+		Env       map[string]string `json:"env"`
+		Endpoints []struct {
+			ID        string `json:"id"`
+			Kind      string `json:"kind"`
+			Label     string `json:"label"`
+			Target    string `json:"target"`
+			Transport string `json:"transport"`
+			Protocol  string `json:"protocol"`
+			Bind      string `json:"bind"`
+			URL       string `json:"url"`
+			Port      struct {
+				Default  int    `json:"default"`
+				Strategy string `json:"strategy"`
+			} `json:"port"`
+		} `json:"endpoints"`
+	}
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("decode endpoint contract: %v", err)
+	}
+
+	expectedEnv := map[string]string{
+		"ECHO_PORT":             "${endpoint.service.port}",
+		"ECHO_HTTP_HEALTH_PORT": "${endpoint.http_health.port}",
+		"ECHO_TCP_PORT":         "${endpoint.tcp_health.port}",
+	}
+	for key, expected := range expectedEnv {
+		if actual := manifest.Env[key]; actual != expected {
+			t.Errorf("%s = %q, want %q", key, actual, expected)
+		}
+	}
+
+	type networkExpectation struct {
+		port     int
+		protocol string
+	}
+	expectedNetworks := map[string]networkExpectation{
+		"service":     {port: 4010, protocol: "http"},
+		"http_health": {port: 4011, protocol: "http"},
+		"tcp_health":  {port: 4012, protocol: "tcp"},
+	}
+	expectedURLs := map[string]struct {
+		label  string
+		target string
+		url    string
+	}{
+		"ui": {
+			label:  "ui",
+			target: "service",
+			url:    "http://${endpoint.service.bind}:${endpoint.service.port}/",
+		},
+		"service_health": {
+			label:  "service",
+			target: "service",
+			url:    "http://${endpoint.service.bind}:${endpoint.service.port}/health",
+		},
+		"http_health_url": {
+			label:  "http-health",
+			target: "http_health",
+			url:    "http://${endpoint.http_health.bind}:${endpoint.http_health.port}/health",
+		},
+	}
+
+	seen := make(map[string]bool, len(manifest.Endpoints))
+	for _, endpoint := range manifest.Endpoints {
+		if endpoint.ID == "" {
+			t.Fatal("endpoint id must not be empty")
+		}
+		if seen[endpoint.ID] {
+			t.Fatalf("duplicate endpoint id %q", endpoint.ID)
+		}
+		seen[endpoint.ID] = true
+
+		switch endpoint.Kind {
+		case "network":
+			expected, ok := expectedNetworks[endpoint.ID]
+			if !ok {
+				t.Errorf("unexpected network endpoint %q", endpoint.ID)
+				continue
+			}
+			if endpoint.Bind != "127.0.0.1" || endpoint.Transport != "tcp" || endpoint.Protocol != expected.protocol {
+				t.Errorf("network endpoint %q has unexpected binding: bind=%q transport=%q protocol=%q", endpoint.ID, endpoint.Bind, endpoint.Transport, endpoint.Protocol)
+			}
+			if endpoint.Port.Default != expected.port || endpoint.Port.Strategy != "preferred" {
+				t.Errorf("network endpoint %q has port default=%d strategy=%q, want %d/preferred", endpoint.ID, endpoint.Port.Default, endpoint.Port.Strategy, expected.port)
+			}
+		case "url":
+			expected, ok := expectedURLs[endpoint.ID]
+			if !ok {
+				t.Errorf("unexpected URL endpoint %q", endpoint.ID)
+				continue
+			}
+			if endpoint.Label != expected.label || endpoint.Target != expected.target || endpoint.URL != expected.url {
+				t.Errorf("URL endpoint %q = label %q target %q url %q, want label %q target %q url %q", endpoint.ID, endpoint.Label, endpoint.Target, endpoint.URL, expected.label, expected.target, expected.url)
+			}
+		default:
+			t.Errorf("unexpected endpoint kind %q for %q", endpoint.Kind, endpoint.ID)
+		}
+	}
+
+	for id := range expectedNetworks {
+		if !seen[id] {
+			t.Errorf("missing network endpoint %q", id)
+		}
+	}
+	for id := range expectedURLs {
+		if !seen[id] {
+			t.Errorf("missing URL endpoint %q", id)
+		}
+	}
+}


### PR DESCRIPTION
Closes #8.

## Summary
- replace legacy top-level `urls` and literal listener ports with canonical `endpoints[]`
- resolve runtime port variables through `${endpoint.<id>.port}` selectors
- add a regression test that rejects legacy `urls`, `ports`, and `portmapping`
- align package documentation and the checked-in manifest example

## Validation
- `go test ./...` — passed
- current Service Lasso core manifest loader — passed before publication
- `git diff --check` — passed

## Review boundary
Draft until hosted checks and cross-repository compatibility evidence are reviewed.